### PR TITLE
parse_cgi_output: Pass $output filehandle directly in response

### DIFF
--- a/lib/CGI/Parse/PSGI.pm
+++ b/lib/CGI/Parse/PSGI.pm
@@ -48,19 +48,7 @@ sub parse_cgi_output {
         ];
     }
 
-    # TODO we can pass $output to the response body without buffering all?
-
-    {
-        my $length = 0;
-        while ( $output->read( my $buffer, 4096 ) ) {
-            $length += length($buffer);
-            $response->add_content($buffer);
-        }
-
-        if ( $length && !$response->content_length ) {
-            $response->content_length($length);
-        }
-    }
+    $response->content_length($remaining);
 
     return [
         $status,
@@ -70,7 +58,7 @@ sub parse_cgi_output {
                 map { ( $k => $_ ) } $response->headers->header($_);
             } $response->headers->header_field_names
         ],
-        [$response->content],
+        $output,
     ];
 }
 


### PR DESCRIPTION
Greetings, this is a patch to pass the filehandle directly in the PSGI response, instead of passing a buffer of content read from that filehandle.  Brock mentioned you might be taking a different direction and removing the temp file, so you can reject if this isn't what you want :)

Thanks for PSGI, we love it!
