### PR TITLE
Respect an NPH script's HTTP status line

### DIFF
--- a/lib/CGI/Parse/PSGI.pm
+++ b/lib/CGI/Parse/PSGI.pm
@@ -40,8 +40,16 @@ sub parse_cgi_output {
         $response->header('Status', 302);
     }
 
-    my $status = $response->header('Status') || 200;
-    $status =~ s/\s+.*$//; # remove ' OK' in '200 OK'
+    my $status = $response->code || 200;
+    my $status_header = $response->header('Status');
+    if ($status_header) {
+        # Use the header status preferentially, if present and well formed
+
+        # Extract the code from the header (should be 3 digits, non zero)
+        my ($code) = ($status_header =~ /^ \s* (\d+) /x);
+
+        $status = $code || $status;
+    }
 
     $response->remove_header('Status'); # PSGI doesn't allow having Status header in the response
 

--- a/lib/CGI/Parse/PSGI.pm
+++ b/lib/CGI/Parse/PSGI.pm
@@ -6,8 +6,16 @@ our @EXPORT_OK = qw( parse_cgi_output );
 use IO::File; # perl bug: should be loaded to call ->getline etc. on filehandle/PerlIO
 use HTTP::Response;
 
+our %DEFAULT_OPTS = (
+    ignore_status_line => 0,
+);
+
 sub parse_cgi_output {
     my $output = shift;
+    my $options = \%DEFAULT_OPTS;
+    if (ref $_[0] eq 'HASH') {
+        $options = { %DEFAULT_OPTS, %{ +shift } }; # Use default opts where none supplied
+    }
 
     my $length;
     if (ref $output eq 'SCALAR') {
@@ -40,7 +48,9 @@ sub parse_cgi_output {
         $response->header('Status', 302);
     }
 
-    my $status = $response->code || 200;
+    my $status = $options->{ignore_status_line}?
+        200 : ($response->code || 200);
+
     my $status_header = $response->header('Status');
     if ($status_header) {
         # Use the header status preferentially, if present and well formed
@@ -109,6 +119,10 @@ CGI::Parse::PSGI - Parses CGI output and creates PSGI response out of it
   my $output = YourApp->run;
   my $psgi_res = parse_cgi_output(\$output);
 
+An option hash can also be passed:
+
+  my $psgi_res = parse_cgi_output(\$output, \%options);
+
 =head1 SYNOPSIS
 
 CGI::Parse::PSGI exports one function C<parse_cgi_output> that takes a
@@ -119,6 +133,39 @@ headers and a body) by reading the output.
 Use L<CGI::Emulate::PSGI> if you have a CGI I<code> not the I<output>,
 which takes care of automatically parsing the output, using this
 module, from your callback code.
+
+=head1 OPTIONS
+
+As mentioned above, C<parse_cgi_output> can accept an options hash as
+the second argument.
+
+Currently the options available are:
+
+=over 4
+
+=item C<ignore_status_line>
+
+A boolean value, defaulting to 0 (false). If true, the status in the
+HTTP protocol line is not used to set the default status in absence of
+a status header.
+
+=back
+
+The options can be supplied to earlier versions, and will be ignored
+without error.  Hence you can preserve legacy behaviour like this:
+
+    parse_cgi_output(\$output, {ignore_status_line => 1});
+
+This will ensure that if the script output includes an edge case
+like this:
+
+    HTTP/1.1 666 SNAFU
+    Content-Type: text/plain
+
+    This should be OK!
+
+then the old behaviour of ignoring the status line and returning 200
+is preserved.
 
 =head1 AUTHOR
 

--- a/t/02_parse.t
+++ b/t/02_parse.t
@@ -92,16 +92,16 @@ CGI
 }
 
 {
-    # Show status is 200 when status line present without status header, and not 200
+    # Check status line is observed when status header is absent
     my $output = <<CGI;
 HTTP/1.0 400 Bad Request
 Content-Type: text/plain
 
-Not found
+Invalid parameters
 CGI
 
     my($r, $h) = _parse($output);
-    is $r->[0], 200;
+    is $r->[0], 400;
 }
 
 {
@@ -115,7 +115,7 @@ Invalid parameters
 CGI
 
     my($r, $h) = _parse($output, {ignore_status_line => 0});
-    is $r->[0], 200;
+    is $r->[0], 400;
 
     ($r, $h) = _parse($output, {ignore_status_line => 1});
     is $r->[0], 200;

--- a/t/02_parse.t
+++ b/t/02_parse.t
@@ -117,9 +117,8 @@ CGI
     my($r, $h) = _parse($output, {ignore_status_line => 0});
     is $r->[0], 400;
 
-# Commented out since this is not yet implemented and will fail.
-#    ($r, $h) = _parse($output, {ignore_status_line => 1});
-#    is $r->[0], 200;
+    ($r, $h) = _parse($output, {ignore_status_line => 1});
+    is $r->[0], 200;
 }
 
 {

--- a/t/02_parse.t
+++ b/t/02_parse.t
@@ -49,6 +49,61 @@ CGI
     is_deeply $r->[2], [ "Redirected\n" ];
 }
 
+{
+    # Check that status header wins when present in addition to status line 200
+    my $output = <<CGI;
+HTTP/1.0 200 OK
+Status: 404
+Content-Type: text/plain
+
+Not found
+CGI
+
+    my($r, $h) = _parse($output);
+    is $r->[0], 404;
+}
+
+{
+    # Check status header (!=200) still wins when status line present, and not 200
+    my $output = <<CGI;
+HTTP/1.0 400 Bad Request
+Status: 404
+Content-Type: text/plain
+
+Not found
+CGI
+
+    my($r, $h) = _parse($output);
+    is $r->[0], 404;
+}
+
+{
+    # Check status header (==200) still wins when status line present, and not 200
+    my $output = <<CGI;
+HTTP/1.0 400 Bad Request
+Status: 200
+Content-Type: text/plain
+
+OK
+CGI
+
+    my($r, $h) = _parse($output);
+    is $r->[0], 200;
+}
+
+{
+    # Show status is 200 when status line present without status header, and not 200
+    my $output = <<CGI;
+HTTP/1.0 400 Bad Request
+Content-Type: text/plain
+
+Not found
+CGI
+
+    my($r, $h) = _parse($output);
+    is $r->[0], 200;
+}
+
 done_testing;
 
 sub _parse {

--- a/t/02_parse.t
+++ b/t/02_parse.t
@@ -104,11 +104,44 @@ CGI
     is $r->[0], 200;
 }
 
+{
+    # Check option hash is ignored when unimplemented -
+    # i.e. status line is not observed even when status header is absent
+    my $output = <<CGI;
+HTTP/1.0 400 Bad Request
+Content-Type: text/plain
+
+Invalid parameters
+CGI
+
+    my($r, $h) = _parse($output, {ignore_status_line => 0});
+    is $r->[0], 200;
+
+    ($r, $h) = _parse($output, {ignore_status_line => 1});
+    is $r->[0], 200;
+}
+
+{
+    # Check option hash is ignored when unimplemented -
+    # i.e. default status is 200 when status header is absent
+    my $output = <<CGI;
+Content-Type: text/plain
+
+Ok
+CGI
+
+    my($r, $h) = _parse($output, {ignore_status_line => 0});
+    is $r->[0], 200;
+
+    ($r, $h) = _parse($output, {ignore_status_line => 1});
+    is $r->[0], 200;
+}
+
 done_testing;
 
 sub _parse {
     my $output = shift;
-    my $r = parse_cgi_output(\$output);
+    my $r = parse_cgi_output(\$output, @_);
 
     my $h = HTTP::Headers->new;
     while (my($k, $v) = splice @{$r->[1]}, 0, 2) {

--- a/t/02_parse.t
+++ b/t/02_parse.t
@@ -117,8 +117,9 @@ CGI
     my($r, $h) = _parse($output, {ignore_status_line => 0});
     is $r->[0], 400;
 
-    ($r, $h) = _parse($output, {ignore_status_line => 1});
-    is $r->[0], 200;
+# Commented out since this is not yet implemented and will fail.
+#    ($r, $h) = _parse($output, {ignore_status_line => 1});
+#    is $r->[0], 200;
 }
 
 {


### PR DESCRIPTION
Hi,

I have some Non-parsed Header CGI scripts which I've been serving via Plack::App::CGIBin.  I notice that when they return non-200 statuses, this is ignored and overridden with a 200 Ok status. 

Currently, CGI::Parse::PSGI::parse_cgi_output will return a 200 OK status when passed a header like this:

```
HTTP/1.0 400 Bad Request
Content-Type: text/plain

Invalid parameters
```

I hope you agree, this doesn't seem sensible.

Checking the source, I can see that this is because the HTTP::Response is used to parse the output, but the resulting instance's ->code attribute is ignored - only the Status: header field is used, and if it is not present the default of 200 is used.

The NPH CGI scripts I am serving return their status in the HTTP status line, not in a "Status:" header field. This seems reasonable, because "Status:" isn't actually a valid HTTP header field. So far as I can see it is only defined in the CGI spec, RFC 3875, and not the HTTP spec, 2616. The CGI spec says the "Status:" header field is meant to be removed before the server sends the response on to the client.

My pull request attempts to make parse_cgi_output do the right thing in this case.  It uses the status from the HTTP header line (HTTP::Response->code) and use it as a default if there is no overriding Status: header field.  Tests included.

I occurred to me that someone may be relying on the old behaviour and expecting an error code in the HTTP status line to be ignored. So I've provided a way of reverting to the legacy behaviour, by supplying an option hash as the second argument:

```
parse_cgi_output(\$output, {ignore_status_line => 1});
```

This argument is ignored by the current implementation and so has no effect - therefore, it can be used to ensure the old behaviour is preserved in any case. Users of Plack::App::CGIBin can't access this option directly without modifications to that module, but as a workaround they could set:

```
$CGI::Parse::PSGI::DEFAULT_OPTS{ignore_status_line} = 1.
```
