### PR TITLE
make localizing STDOUT work properly in the debugger for perl 5.8.8

### DIFF
--- a/lib/CGI/Emulate/PSGI.pm
+++ b/lib/CGI/Emulate/PSGI.pm
@@ -23,7 +23,7 @@ sub handler {
 
             local *STDIN;
             tie (*STDIN, 'CGI::Emulate::PSGI::InputHandle', $env->{'psgi.input'});
-            local *STDOUT = $stdout;
+            local *STDOUT = *$stdout;
             local *STDERR;
             tie (*STDERR, 'CGI::Emulate::PSGI::ErrorsHandle', $env->{'psgi.errors'});
 


### PR DESCRIPTION
Running under the perl debugger (perl 5.8.8), 'local *STDOUT = *$stdout;' doesn't localize STDOUT properly.  Later perl versions and using 'local *STDOUT = *$stdout' work.  Since CGI/Emulate/PSGI.pm localizes STDOUT in this way, running plackup app.psgi under the perl debugger doesn't work in 5.8.8.

Changing local *STDOUT = $stdout to local *STDOUT = *$stdout makes this work on 5.8.8 and doesn't stop it working in newer versions.

$ cat d.pl
use strict;
use warnings;

use IO::File;
print "hello\n";

{
        my $stdout = IO::File->new_tmpfile;
        local *STDOUT = $stdout;
        print "yay!\n";
}

print "bye\n";

$ perl d.pl
hello
bye
$ PERLDB_OPTS="NonStop=1" perl -d d.pl
hello
yay!
bye
$
