### PR TITLE
test (and fix) that we restore the selected FH

### DIFF
--- a/lib/CGI/Emulate/PSGI.pm
+++ b/lib/CGI/Emulate/PSGI.pm
@@ -19,14 +19,16 @@ sub handler {
         my $stdout  = IO::File->new_tmpfile;
 
         {
-            local %ENV = (%ENV, $class->emulate_environment($env));
-
-            local *STDIN  = $env->{'psgi.input'};
-            local *STDOUT = $stdout;
-            local *STDERR = $env->{'psgi.errors'};
-
             my $saver = SelectSaver->new("::STDOUT");
-            $code->();
+            {
+                local %ENV = (%ENV, $class->emulate_environment($env));
+
+                local *STDIN  = $env->{'psgi.input'};
+                local *STDOUT = $stdout;
+                local *STDERR = $env->{'psgi.errors'};
+
+                $code->();
+            }
         }
 
         seek( $stdout, 0, SEEK_SET )

--- a/t/01_simple.t
+++ b/t/01_simple.t
@@ -4,6 +4,8 @@ use CGI;
 use CGI::Emulate::PSGI;
 use Test::More;
 
+my $fh = select;
+
 my $err;
 $ENV{REQUEST_METHOD} = 'GET';
 $ENV{HOK} = 'gahaha';
@@ -37,6 +39,8 @@ my $res = $handler->(
     }
 );
 
+my $post_fh = select;
+
 is $res->[0], 200;
 my $headers = +{@{$res->[1]}};
 is $headers->{'X-Foo'}, 'Bar';
@@ -46,6 +50,8 @@ is_deeply $res->[2], ['KTKR'];
 is $ENV{REQUEST_METHOD}, 'GET', 'restored';
 
 is $err, "hello error\n";
+
+is $fh,$post_fh,'SelectSaver worked';
 
 done_testing;
 


### PR DESCRIPTION
`SelectSaver` was getting confused by the localization of `STDOUT`, and was selecting the tmpfile on destruction. Just moving it outside of the block with the `local`s is enough to make the thing work.