### PR TITLE
Add PSGI streaming interface

### DIFF
--- a/lib/CGI/Emulate/PSGI/Streaming.pm
+++ b/lib/CGI/Emulate/PSGI/Streaming.pm
@@ -1,0 +1,39 @@
+package CGI::Emulate::PSGI::Streaming;
+use strict;
+use warnings;
+use parent 'CGI::Emulate::PSGI';
+use CGI::Parse::PSGI;
+use SelectSaver;
+use Carp qw(croak);
+use 5.008001;
+
+our $VERSION = '0.21';
+
+sub handler {
+    my ($class, $code, ) = @_;
+
+    return sub {
+        my $env = shift;
+
+        my $wrapped_app = sub {
+            my ($stdout) = @_;
+            my $saver = SelectSaver->new("::STDOUT");
+            local %ENV = (%ENV, $class->emulate_environment($env));
+
+            local *STDIN  = $env->{'psgi.input'};
+            local *STDOUT = $stdout;
+            local *STDERR = $env->{'psgi.errors'};
+
+            $code->();
+            close $stdout;
+        };
+
+        return sub {
+            my ($responder) = @_;
+
+            CGI::Parse::PSGI::parse_cgi_output_streaming($responder,$wrapped_app);
+        };
+    };
+}
+
+1;

--- a/lib/CGI/Parse/PSGI.pm
+++ b/lib/CGI/Parse/PSGI.pm
@@ -1,7 +1,7 @@
 package CGI::Parse::PSGI;
 use strict;
 use base qw(Exporter);
-our @EXPORT_OK = qw( parse_cgi_output );
+our @EXPORT_OK = qw( parse_cgi_output parse_cgi_output_streaming );
 
 use IO::File; # perl bug: should be loaded to call ->getline etc. on filehandle/PerlIO
 use HTTP::Response;
@@ -78,6 +78,85 @@ sub parse_cgi_output {
         ],
         [$response->content],
     ];
+}
+
+sub parse_cgi_output_streaming {
+    my ($responder, $code) = @_;
+
+    my $output = \do {local *HANDLE};
+    my $headers;
+    my $response;
+    my $writer;
+
+    require CGI::Parse::PSGI::Handle;
+
+    tie *$output,'CGI::Parse::PSGI::Handle', sub {
+        my ($data) = @_;
+
+        # if we're still parsing the headers
+        if (!$response) {
+            if (defined $data) {
+                $headers .= $data;
+            }
+            else { # closed file before the end of headers
+                $headers = "HTTP/1.1 500 Internal Server Error\x0d\x0a";
+            }
+
+            # still more headers to come, return to the CGI
+            return unless $headers =~ /\x0d?\x0a\x0d?\x0a/;
+
+            ($headers,$data) =
+                ($headers =~ m{\A(.+?)\x0d?\x0a\x0d?\x0a(.*)\z}sm);
+
+            unless ( $headers =~ /^HTTP/ ) {
+                $headers = "HTTP/1.1 200 OK\x0d\x0a" . $headers;
+            }
+
+            $response = HTTP::Response->parse($headers);
+
+            # RFC 3875 6.2.3
+            if ($response->header('Location') && !$response->header('Status')) {
+                $response->header('Status', 302);
+            }
+        }
+
+        if ($response) { # we have parsed the headers
+            if ( $response->code == 500 && !defined($data) ) {
+                # ended after a raw 500
+                $responder->([
+                    500,
+                    [ 'Content-Type' => 'text/html' ],
+                    [ $response->error_as_HTML ]
+                ]);
+                return;
+            }
+            if (!$writer) {
+                my $status = $response->header('Status') || 200;
+                $status =~ s/\s+.*$//; # remove ' OK' in '200 OK'
+                # PSGI doesn't allow having Status header in the response
+                $response->remove_header('Status');
+
+                $writer = $responder->([
+                    $status,
+                    +[
+                        map {
+                            my $k = $_;
+                            map { ( $k => _cleanup_newline($_) ) }
+                                $response->headers->header($_);
+                        } $response->headers->header_field_names
+                    ],
+                ]);
+            }
+            if (defined $data) {
+                $writer->write($data) if length($data);
+            }
+            else {
+                $writer->close;
+            }
+        }
+    };
+
+    $code->($output);
 }
 
 sub _cleanup_newline {

--- a/lib/CGI/Parse/PSGI/Handle.pm
+++ b/lib/CGI/Parse/PSGI/Handle.pm
@@ -1,0 +1,42 @@
+package CGI::Parse::PSGI::Handle;
+use strict;
+use warnings;
+use POSIX 'SEEK_SET';
+use parent 'Tie::Handle';
+
+sub TIEHANDLE {
+    my ($class,$callback) = @_;
+
+    my $self = { cb => $callback, buffer => '' };
+    open $self->{fh},'>',\($self->{buffer});
+    return bless $self, $class;
+}
+
+sub BINMODE {
+    my ($self, $layer) = @_;
+    if (@_==2) {
+        binmode $self->{fh},$layer;
+    }
+    else {
+        binmode $self->{fh};
+    }
+}
+
+sub WRITE {
+    my ($self,$buf,$len,$offset) = @_;
+    seek( $self->{fh}, 0, SEEK_SET );
+    $self->{buffer}='';
+    print {$self->{fh}} substr($buf, $offset, $len);
+
+    $self->{cb}->($self->{buffer});
+    return $len;
+}
+
+sub CLOSE {
+    my ($self) = @_;
+    close $self->{fh};
+    $self->{cb}->();
+    return 1;
+}
+
+1;

--- a/t/05_lint.t
+++ b/t/05_lint.t
@@ -5,6 +5,7 @@ use Test::Requires {
     'Plack' => 0.9981,
 };
 use CGI::Emulate::PSGI;
+use CGI::Emulate::PSGI::Streaming;
 
 my $output = <<CGI;
 Status: 302
@@ -17,13 +18,18 @@ Multiline: Foo
 This is the body!
 CGI
 
-my $app = CGI::Emulate::PSGI->handler(sub { print $output });
-$app = Plack::Middleware::Lint->wrap($app);
+sub test_it {
+    my ($app) = @_;
+    $app = Plack::Middleware::Lint->wrap($app);
 
-Plack::Test::test_psgi($app, sub {
-    my $cb = shift;
-    my $res = $cb->(HTTP::Request->new(GET => "/"));
-    is $res->code, 302;
-});
+    Plack::Test::test_psgi($app, sub {
+        my $cb = shift;
+        my $res = $cb->(HTTP::Request->new(GET => "/"));
+        is $res->code, 302;
+    });
+}
+
+test_it(CGI::Emulate::PSGI->handler(sub { print $output }));
+test_it(CGI::Emulate::PSGI::Streaming->handler(sub { print $output }));
 
 done_testing;

--- a/t/06_stream.t
+++ b/t/06_stream.t
@@ -1,0 +1,103 @@
+use strict;
+use warnings;
+use CGI;
+use CGI::Emulate::PSGI::Streaming;
+use Plack::Util;
+use Test::More tests=>13;
+use Test::Deep;
+use Data::Dump 'pp';
+
+my $fh = select;
+
+my $handler = CGI::Emulate::PSGI::Streaming->handler(
+    sub {
+        binmode STDOUT, ":utf8";
+        my $special=chr(4242);
+        print "Content-Type: text/html; charset=utf-8\r\n";
+        print "\r\n";
+        print STDERR "first error\n";
+        print "first block $special\r\n";
+        sleep 1;
+        print STDERR "second error\n";
+        print "second block $special\r\n";
+    }
+);
+
+my $err;
+open my $in, '<', \do { my $body = '' };
+open my $errors, '>', \$err;
+my $res = $handler->(
+    +{
+        'psgi.input'   => $in,
+        REMOTE_ADDR    => '192.168.1.1',
+        REQUEST_METHOD => 'GET',
+        'psgi.errors'  => $errors,
+    }
+);
+
+
+my $post_fh = select;
+
+is(ref($res),'CODE','::Streaming should return a coderef');
+is($post_fh,$fh,'SelectSaver worked before callback');
+
+$res->(
+    sub {
+        my ($response) = @_;
+        cmp_deeply(
+            $response,
+            [
+                200,
+                [
+                    'Content-Type' => 'text/html; charset=utf-8',
+                ],
+            ],
+            'the responder should get a 200 status and content-type header',
+        );
+
+        $post_fh = select;
+        is($post_fh,$fh,'SelectSaver worked after headers');
+
+        my $step=0;
+        my $o = Plack::Util::inline_object(
+            write => sub {
+                my ($data) = @_;
+
+                $post_fh = select;
+                is($post_fh,$fh,'SelectSaver worked during output');
+
+                if ($step == 0) {
+                    is(
+                        $data,"first block \xe1\x82\x92\r\n",
+                        'first print should have the first block',
+                    ) or note pp $data;
+                    is(
+                        $err,"first error\n",
+                        'first print STDERR should have the first error',
+                    );
+                }
+                else {
+                    is(
+                        $data,"second block \xe1\x82\x92\r\n",
+                        'second print should have the second block',
+                    ) or note pp $data;
+                    is(
+                        $err,"first error\nsecond error\n",
+                        'second print STDERR should have the second error',
+                    );
+                }
+                ++$step;
+            },
+            close => sub {
+                $post_fh = select;
+                is($post_fh,$fh,'SelectSaver worked in close');
+
+                is($step,2,'two blocks should have been printed');
+            },
+        );
+        return $o;
+    },
+);
+
+$post_fh = select;
+is($post_fh,$fh,'SelectSaver worked at the end');

--- a/t/07_parse_stream.t
+++ b/t/07_parse_stream.t
@@ -1,0 +1,75 @@
+use strict;
+use Test::More;
+use Plack::Util;
+use CGI::Parse::PSGI qw(parse_cgi_output_streaming);
+
+{
+    my $output = <<CGI;
+Status: 302
+Content-Type: text/html
+X-Foo: bar
+Location: http://localhost/
+
+This is the body!
+CGI
+
+    my($r, $h) = _parse($output);
+    is $r->[0], 302;
+
+    is $h->content_type, 'text/html';
+    is $h->header('Location'), 'http://localhost/';
+
+    is_deeply $r->[2], [ "This is the body!\n" ];
+}
+
+{
+    # rfc3875 6.2.3
+    my $output = <<CGI;
+Location: http://google.com/
+
+CGI
+    my($r, $h) = _parse($output);
+    is $r->[0], 302;
+    is $h->header('Location'), 'http://google.com/';
+}
+
+{
+    # rfc3875 6.2.4
+    my $output = <<CGI;
+Status: 301
+Location: http://google.com/
+Content-Type: text/html
+
+Redirected
+CGI
+    my($r, $h) = _parse($output);
+    is $r->[0], 301;
+    is $h->header('Location'), 'http://google.com/';
+    is $h->content_type, 'text/html';
+    is_deeply $r->[2], [ "Redirected\n" ];
+}
+
+done_testing;
+
+sub _parse {
+    my $output = shift;
+    my $r;
+    my $responder = sub {
+        my ($response) = @_;
+        $r = $response;
+        return Plack::Util::inline_object(
+            write => sub { push @{$r->[2]}, shift },
+            close => sub {},
+        );
+    };
+    parse_cgi_output_streaming(
+        $responder,
+        sub { print {shift} $output },
+    );
+
+    my $h = HTTP::Headers->new;
+    while (my($k, $v) = splice @{$r->[1]}, 0, 2) {
+        $h->header($k, $v);
+    }
+    return $r, $h;
+}


### PR DESCRIPTION
Sometimes a CGI will print stuff while it's working. This should map to the PSGI "streaming response" style.

This branch adds a `CGI::Emulate::PSGI::Streaming` that does exactly that.
The implementation is a bit convoluted: `*STDOUT` is tied to a class that will invoke a callback when printed to, and `CGI::Parse::PSGI::parse_cgi_output_streaming` uses it to incrementally parse headers and body, and emitting data to PSGI as soon as possible.

If you like this feature and approach, I'll add documentation.

The work is copyrighted Broadbean.com, licenced under the same terms as Perl itself.