### PR TITLE
Do not set HTTP_PROXY env to prevent httpoxy vulnerability

### DIFF
--- a/lib/CGI/Emulate/PSGI.pm
+++ b/lib/CGI/Emulate/PSGI.pm
@@ -50,7 +50,7 @@ sub emulate_environment {
         REMOTE_HOST     => 'localhost',
         REMOTE_PORT     => int( rand(64000) + 1000 ),    # not in RFC 3875
         # REQUEST_URI     => $uri->path_query,                 # not in RFC 3875
-        ( map { $_ => $env->{$_} } grep !/^psgix?\./, keys %$env )
+        ( map { $_ => $env->{$_} } grep { $_ ne "HTTP_PROXY" } grep !/^psgix?\./, keys %$env )
     };
 
     return wantarray ? %$environment : $environment;

--- a/lib/CGI/Emulate/PSGI.pm
+++ b/lib/CGI/Emulate/PSGI.pm
@@ -50,7 +50,7 @@ sub emulate_environment {
         REMOTE_HOST     => 'localhost',
         REMOTE_PORT     => int( rand(64000) + 1000 ),    # not in RFC 3875
         # REQUEST_URI     => $uri->path_query,                 # not in RFC 3875
-        ( map { $_ => $env->{$_} } grep { $_ ne "HTTP_PROXY" } grep !/^psgix?\./, keys %$env )
+        ( map { $_ => $env->{$_} } grep { !/^psgix?\./ && $_ ne "HTTP_PROXY" } keys %$env )
     };
 
     return wantarray ? %$environment : $environment;

--- a/t/06_httproxy.t
+++ b/t/06_httproxy.t
@@ -1,0 +1,36 @@
+use strict;
+use warnings;
+use CGI;
+use CGI::Emulate::PSGI;
+use Test::More;
+
+my $handler = CGI::Emulate::PSGI->handler(
+    sub {
+        ok ! exists $ENV{HTTP_PROXY};
+        print "Content-Type: text/html; charset=utf-8\r\n";
+        print "Content-Length: 4\r\n";
+        print "\r\n";
+        print "KTKR";
+    }
+);
+
+my $input = "";
+open my $in, '<', \$input;
+open my $errors, '>', \my $err;
+my $res = $handler->(
+    +{
+        'psgi.input'   => $in,
+        REMOTE_ADDR    => '192.168.1.1',
+        REQUEST_METHOD => 'GET',
+        HTTP_PROXY     => 'localhost:3128',
+        'psgi.errors'  => $errors,
+    }
+);
+
+
+is $res->[0], 200;
+my $headers = +{@{$res->[1]}};
+
+
+done_testing;
+


### PR DESCRIPTION
To prevent httproxy vulnerability (https://httpoxy.org/), This PR do not set HTTP_PROXY as environment  value.


